### PR TITLE
Fix renderer fallback for default chroma option

### DIFF
--- a/electron/main/ipc/skins.ipc.ts
+++ b/electron/main/ipc/skins.ipc.ts
@@ -9,6 +9,12 @@ export function registerSkinsIpc(
 
   ipcMain.handle("get-include-default", () => svc.getIncludeDefault());
   ipcMain.handle("toggle-include-default", () => svc.toggleIncludeDefault());
+  ipcMain.handle("get-include-default-chroma", () =>
+    svc.getIncludeDefaultChroma()
+  );
+  ipcMain.handle("toggle-include-default-chroma", () =>
+    svc.toggleIncludeDefaultChroma()
+  );
 
   ipcMain.handle("get-auto-roll", () => svc.getAutoRoll());
   ipcMain.handle("toggle-auto-roll", () => svc.toggleAutoRoll());

--- a/electron/main/windows/tray.ts
+++ b/electron/main/windows/tray.ts
@@ -96,7 +96,6 @@ export function updaterHooks() {
   autoUpdater.on("update-available", (info: any) => {
     if (manualUpdateRequested) {
       // app never used
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { dialog } = require("electron");
       dialog.showMessageBox({
         type: "info",

--- a/electron/preload/api.d.ts
+++ b/electron/preload/api.d.ts
@@ -21,6 +21,8 @@ declare global {
 
       getIncludeDefault: () => Promise<boolean>;
       toggleIncludeDefault: () => Promise<void>;
+      getIncludeDefaultChroma: () => Promise<boolean>;
+      toggleIncludeDefaultChroma: () => Promise<void>;
       getAutoRoll: () => Promise<boolean>;
       toggleAutoRoll: () => Promise<void>;
 

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -38,6 +38,10 @@ const api = {
   /* Options */
   getIncludeDefault: () => ipcRenderer.invoke("get-include-default"),
   toggleIncludeDefault: () => ipcRenderer.invoke("toggle-include-default"),
+  getIncludeDefaultChroma: () =>
+    ipcRenderer.invoke("get-include-default-chroma"),
+  toggleIncludeDefaultChroma: () =>
+    ipcRenderer.invoke("toggle-include-default-chroma"),
   getAutoRoll: () => ipcRenderer.invoke("get-auto-roll"),
   toggleAutoRoll: () => ipcRenderer.invoke("toggle-auto-roll"),
 

--- a/src/components/controls/OptionsPanel.tsx
+++ b/src/components/controls/OptionsPanel.tsx
@@ -3,15 +3,22 @@ import { api } from "@/features/api";
 export default function OptionsPanel({
   includeDefault,
   setIncludeDefault,
+  includeDefaultChroma,
+  setIncludeDefaultChroma,
   autoRoll,
   setAutoRoll,
   savePref,
 }: {
   includeDefault: boolean;
   setIncludeDefault: (v: boolean) => void;
+  includeDefaultChroma: boolean;
+  setIncludeDefaultChroma: (v: boolean) => void;
   autoRoll: boolean;
   setAutoRoll: (v: boolean) => void;
-  savePref: (k: "includeDefault" | "autoRoll", v: boolean) => void;
+  savePref: (
+    k: "includeDefault" | "includeDefaultChroma" | "autoRoll",
+    v: boolean
+  ) => void;
 }) {
   const toggleInclude = () => {
     api
@@ -20,6 +27,16 @@ export default function OptionsPanel({
       .then((val) => {
         setIncludeDefault(val);
         savePref("includeDefault", val);
+      });
+  };
+
+  const toggleIncludeChroma = () => {
+    api
+      .toggleIncludeDefaultChroma()
+      .then(() => api.getIncludeDefaultChroma())
+      .then((val) => {
+        setIncludeDefaultChroma(val);
+        savePref("includeDefaultChroma", val);
       });
   };
 
@@ -43,6 +60,16 @@ export default function OptionsPanel({
         />
         <span className="dot" />
         <span className="txt">Include default skin</span>
+      </label>
+
+      <label className="option">
+        <input
+          type="checkbox"
+          checked={includeDefaultChroma}
+          onChange={toggleIncludeChroma}
+        />
+        <span className="dot" />
+        <span className="txt">Include default chroma</span>
       </label>
 
       <label className="option">

--- a/src/features/api.ts
+++ b/src/features/api.ts
@@ -22,6 +22,14 @@ export const api = {
   // options
   getIncludeDefault: () => lcu.getIncludeDefault(),
   toggleIncludeDefault: () => lcu.toggleIncludeDefault(),
+  getIncludeDefaultChroma: () =>
+    typeof lcu.getIncludeDefaultChroma === "function"
+      ? lcu.getIncludeDefaultChroma()
+      : Promise.resolve(false),
+  toggleIncludeDefaultChroma: () =>
+    typeof lcu.toggleIncludeDefaultChroma === "function"
+      ? lcu.toggleIncludeDefaultChroma()
+      : Promise.resolve(),
   getAutoRoll: () => lcu.getAutoRoll(),
   toggleAutoRoll: () => lcu.toggleAutoRoll(),
 

--- a/src/features/hooks/usePrefs.ts
+++ b/src/features/hooks/usePrefs.ts
@@ -1,8 +1,13 @@
 export function usePrefs() {
-  const save = (k: "includeDefault" | "autoRoll", v: boolean) =>
+  const save = (
+    k: "includeDefault" | "includeDefaultChroma" | "autoRoll",
+    v: boolean
+  ) =>
     localStorage.setItem(`pref-${k}`, String(v));
 
-  const read = (k: "includeDefault" | "autoRoll") => {
+  const read = (
+    k: "includeDefault" | "includeDefaultChroma" | "autoRoll"
+  ) => {
     const raw = localStorage.getItem(`pref-${k}`);
     return raw !== null ? raw === "true" : null;
   };

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -14,23 +14,33 @@ export default function Settings() {
 
   const { save, read } = usePrefs();
   const [includeDefault, setIncludeDefault] = useState(true);
+  const [includeDefaultChroma, setIncludeDefaultChroma] = useState(false);
   const [autoRoll, setAutoRoll] = useState(true);
 
   useEffect(() => {
-    Promise.all([api.getIncludeDefault(), api.getAutoRoll()]).then(
-      ([incSrv, autoSrv]) => {
-        const incPref = read("includeDefault");
-        const autoPref = read("autoRoll");
+    Promise.all([
+      api.getIncludeDefault(),
+      api.getIncludeDefaultChroma(),
+      api.getAutoRoll(),
+    ]).then(([incSrv, incChromaSrv, autoSrv]) => {
+      const incPref = read("includeDefault");
+      const incChromaPref = read("includeDefaultChroma");
+      const autoPref = read("autoRoll");
 
-        if (incPref !== null && incPref !== incSrv) {
-          api.toggleIncludeDefault().then(() => setIncludeDefault(incPref));
-        } else setIncludeDefault(incSrv);
+      if (incPref !== null && incPref !== incSrv) {
+        api.toggleIncludeDefault().then(() => setIncludeDefault(incPref));
+      } else setIncludeDefault(incSrv);
 
-        if (autoPref !== null && autoPref !== autoSrv) {
-          api.toggleAutoRoll().then(() => setAutoRoll(autoPref));
-        } else setAutoRoll(autoSrv);
-      }
-    );
+      if (incChromaPref !== null && incChromaPref !== incChromaSrv) {
+        api
+          .toggleIncludeDefaultChroma()
+          .then(() => setIncludeDefaultChroma(incChromaPref));
+      } else setIncludeDefaultChroma(incChromaSrv);
+
+      if (autoPref !== null && autoPref !== autoSrv) {
+        api.toggleAutoRoll().then(() => setAutoRoll(autoPref));
+      } else setAutoRoll(autoSrv);
+    });
   }, [read]);
 
   return (
@@ -44,6 +54,11 @@ export default function Settings() {
           setIncludeDefault={(v) => {
             setIncludeDefault(v);
             save("includeDefault", v);
+          }}
+          includeDefaultChroma={includeDefaultChroma}
+          setIncludeDefaultChroma={(v) => {
+            setIncludeDefaultChroma(v);
+            save("includeDefaultChroma", v);
           }}
           autoRoll={autoRoll}
           setAutoRoll={(v) => {


### PR DESCRIPTION
## Summary
- guard the renderer API layer so missing include-default-chroma hooks fall back gracefully

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3cd2f9318832b83cc2e1a55fbd235